### PR TITLE
Add NSTimer reference as block parameter

### DIFF
--- a/NSTimer+Block/NSTimer+Block.h
+++ b/NSTimer+Block/NSTimer+Block.h
@@ -17,7 +17,7 @@
  @param block The block to be executed when the timer fire. The block should take no parameters and have no return value.
  @return The receiver, initialized such that, when added to a run loop, it will fire at date and then, if repeats is YES, every seconds after that.
  */
-- (instancetype)initWithFireDate:(NSDate *)date interval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block;
+- (instancetype)initWithFireDate:(NSDate *)date interval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block;
 
 /**
  Creates and returns a new NSTimer object and schedules it on the current run loop in the default mode.
@@ -26,7 +26,7 @@
  @param block The block to be executed when the timer fire. The block should take no parameters and have no return value.
  @return A new NSTimer object, configured according to the specified parameters.
  */
-+ (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block;
++ (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block;
 
 /**
  Creates and returns a new NSTimer object initialized with the specified block.
@@ -34,6 +34,6 @@
  @param repeats If YES, the timer will repeatedly reschedule itself until invalidated. If NO, the timer will be invalidated after it fires.
  @param block The block to be executed when the timer fire. The block should take no parameters and have no return value.
  */
-+ (NSTimer *)timerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block;
++ (NSTimer *)timerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block;
 
 @end

--- a/NSTimer+Block/NSTimer+Block.m
+++ b/NSTimer+Block/NSTimer+Block.m
@@ -9,17 +9,17 @@
 
 @implementation NSTimer (Block)
 
-- (instancetype)initWithFireDate:(NSDate *)date interval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block
+- (instancetype)initWithFireDate:(NSDate *)date interval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block
 {
     return [self initWithFireDate:date interval:seconds target:self.class selector:@selector(runBlock:) userInfo:block repeats:repeats];
 }
 
-+ (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block
++ (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block
 {
     return [self scheduledTimerWithTimeInterval:seconds target:self selector:@selector(runBlock:) userInfo:block repeats:repeats];
 }
 
-+ (NSTimer *)timerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(void))block
++ (NSTimer *)timerWithTimeInterval:(NSTimeInterval)seconds repeats:(BOOL)repeats block:(void (^)(NSTimer*))block
 {
     return [self timerWithTimeInterval:seconds target:self selector:@selector(runBlock:) userInfo:block repeats:repeats];
 }
@@ -30,8 +30,8 @@
 {
     if ([timer.userInfo isKindOfClass:NSClassFromString(@"NSBlock")])
     {
-        void (^block)(void) = timer.userInfo;
-        block();
+        void (^block)(NSTimer*) = timer.userInfo;
+        block(timer);
     }
 }
 


### PR DESCRIPTION
This provides the ability for a block to do things like invalidate its calling timer, etc. 

This could be a naive implementation; would love to learn if this causes some sort of retain cycle I'm overlooking.
